### PR TITLE
Fixed the login api bug, user once logged in can't be logged in again…

### DIFF
--- a/backend/webapp/views/auth.go
+++ b/backend/webapp/views/auth.go
@@ -22,6 +22,14 @@ import (
 func LoginView(db *gorm.DB) gin.HandlerFunc {
 	fn := func(c *gin.Context) {
 		session := sessions.Default(c)
+		v := session.Get("uId")
+		if v != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"result": "User Already Logged In",
+			})
+			return
+		}
+
 		var json m.Login
 		// try to bind the request json to the Login struct
 		if err := c.ShouldBindJSON(&json); err != nil {


### PR DESCRIPTION
- Login API has a bug
- If login is requested again, it creates a new session. 
- Fixed the bug by checking if the user session is set or not
- If session is already present then returning "User Already Logged In" response